### PR TITLE
Error handling for json parsing.

### DIFF
--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -44,7 +44,13 @@ def validate_language(langs):
 
 
 def translate_attr(attrJson, language):
-    attr = json.loads(attrJson)
+    try:
+        attr = json.loads(attrJson)
+    except:
+        print(f"Error parsing {attrJson}.")
+        print("Expected this to be a dict of translations. Either the json is malformed or the attribute was translated already.")
+        return attrJson
+    
     ret_lang = default_language
 
     if language is not None:


### PR DESCRIPTION
Now logs what string caused an error and gives explanation why it probably happened.
The two cases are
1) Attribute string was already translated, which means something funky might've happened with the previous function
2) The json was malformed, which means it is wrong in the database

modified:   src/views/__init__.py