### PR TITLE
Filtering options for sessions view

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,7 +16,6 @@ a.disabled {
   opacity: 0.4;
 }
 
-
 /* The switch - the box around the slider */
 .switch {
   position: relative;

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -15,3 +15,60 @@ a.disabled {
   cursor: default;
   opacity: 0.4;
 }
+
+
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 34px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 26px;
+  width: 26px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}

--- a/src/templates/resultsView.html
+++ b/src/templates/resultsView.html
@@ -64,7 +64,6 @@
 <script async defer type="text/javascript">
     $(document).ready(function () {
         var table = $('#table_id').DataTable();
-
         $("#filteroo").click(function () {
             if ($("#filteroo").is(':checked'))
                 table

--- a/src/templates/resultsView.html
+++ b/src/templates/resultsView.html
@@ -8,8 +8,13 @@
 
 
 <div class="container text-center">
-
     <div class="container">
+        <br />
+            <p> Hide "None" columns </p>
+            <label class="switch">
+                <input id="filteroo" type="checkbox">
+                <span class="slider"></span>
+        </div>
         <table id="table_id" style="margin-top:2rem;" class="table tablez table-striped table-dark table-sm">
             <thead>
                 <tr>
@@ -52,7 +57,25 @@
         $('.tablez').DataTable({
             "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]],
             "pageLength": 25,
-            "order": [[ 0, "desc" ]]
+            "order": [[0, "desc"]]
+        });
+    });
+</script>
+<script async defer type="text/javascript">
+    $(document).ready(function () {
+        var table = $('#table_id').DataTable();
+
+        $("#filteroo").click(function () {
+            if ($("#filteroo").is(':checked'))
+                table
+                    .columns(0)
+                    .search('^((?!None).)*$', true, false)
+                    .draw();
+            else
+                table
+                    .columns(0)
+                    .search('')
+                    .draw();
         });
     });
 </script>

--- a/src/templates/resultsView.html
+++ b/src/templates/resultsView.html
@@ -10,7 +10,7 @@
 <div class="container text-center">
     <div class="container">
         <br />
-            <p> Hide "None" columns </p>
+            <p> Hide sessions without a selected class </p>
             <label class="switch">
                 <input id="filteroo" type="checkbox">
                 <span class="slider"></span>


### PR DESCRIPTION
MODIFIED:
>styles.css
- Added styling for a slider checkbox
> resultsview.html
- Added a checkbox, and a javascript that filters the datatable based on the state of the checkbox
>adminView.py
- Modified the results_view() method so that it now takes a "min" argument in the URL, and then filters the data by that amount of answers. Default is 1, so empty data is filtered by default.

closes Ohtu-FaceTed/FaceTed-Search#157
closes Ohtu-FaceTed/FaceTed-Search#154